### PR TITLE
🐛 fix(analytics): rename widget id to bypass ad blockers

### DIFF
--- a/src/components/widget/UmamiStats.astro
+++ b/src/components/widget/UmamiStats.astro
@@ -18,7 +18,7 @@ const config = {
 };
 ---
 
-<WidgetLayout name="Site Stats" id="umami-stats" class={className} {style}>
+<WidgetLayout name="Site Stats" id="site-analytics" class={className} {style}>
 	<div class="stats-grid" id="site-stats-container">
 		<!-- Page Views Card -->
 		<div class="stat-card group">


### PR DESCRIPTION
Closes #17